### PR TITLE
Return nonzero to shell after a GuruCliException

### DIFF
--- a/src/main/java/com/amazonaws/gurureviewercli/Main.java
+++ b/src/main/java/com/amazonaws/gurureviewercli/Main.java
@@ -141,6 +141,7 @@ public class Main {
         } catch (GuruCliException e) {
             Log.error("%s: %s", e.getErrorCode(), e.getMessage());
             e.printStackTrace();
+            System.exit(3);
         } catch (ParameterException e) {
             Log.error(e);
             jCommander.usage();


### PR DESCRIPTION
Is there any legitimate circumstance where a GuruCliException arises yet we want to consider the run a success? If not, we should let the program invoker know that we failed.
