### PR TITLE
Remap SARIF severity levels for compatibility with GitHub Action

### DIFF
--- a/src/main/java/com/amazonaws/gurureviewercli/adapter/ResultsAdapter.java
+++ b/src/main/java/com/amazonaws/gurureviewercli/adapter/ResultsAdapter.java
@@ -214,8 +214,8 @@ public final class ResultsAdapter {
             case LOW:
                 return Result.Level.NOTE.value();
             case MEDIUM:
-                return Result.Level.WARNING.value();
             case HIGH:
+                return Result.Level.WARNING.value();
             case CRITICAL:
                 return Result.Level.ERROR.value();
             default:

--- a/src/main/java/com/amazonaws/gurureviewercli/adapter/ResultsAdapter.java
+++ b/src/main/java/com/amazonaws/gurureviewercli/adapter/ResultsAdapter.java
@@ -211,13 +211,11 @@ public final class ResultsAdapter {
         }
         switch (recommendation.severity()) {
             case INFO:
-                return Result.Level.NONE.value();
             case LOW:
-                return Result.Level.NONE.value();
+                return Result.Level.NOTE.value();
             case MEDIUM:
-                return Result.Level.NONE.value();
-            case HIGH:
                 return Result.Level.WARNING.value();
+            case HIGH:
             case CRITICAL:
                 return Result.Level.ERROR.value();
             default:


### PR DESCRIPTION
Changes:
- Map `Info` to `NOTE` (instead of `NONE`)
- Map `Low` to `NOTE` (instead of `NONE`)
- Map `Medium` to `WARNING` (instead of `NONE`)

This should bring the CLI SARIF output closer to the CI/CD SARIF output.